### PR TITLE
feat: Implement booking confirmation and cancellation logic

### DIFF
--- a/backend/confirm_appointment_lambda/test_lambda_function.py
+++ b/backend/confirm_appointment_lambda/test_lambda_function.py
@@ -1,0 +1,274 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import os
+
+# Import the Lambda function to test
+from backend.confirm_appointment_lambda.lambda_function import lambda_handler
+
+class TestConfirmAppointmentLambda(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Mock environment variables before importing the lambda function if it reads them at global scope
+        # However, our lambda_function.py reads them inside the handler or at module level after logger.
+        # For safety, we set them up here.
+        os.environ['APPOINTMENTS_TABLE_NAME'] = 'mock_appointments_table'
+        os.environ['NOTIFICATION_SQS_URL'] = 'mock_notification_sqs_url'
+        os.environ['GOOGLE_CALENDAR_SYNC_SQS_URL'] = 'mock_google_calendar_sqs_url'
+        os.environ['LOG_LEVEL'] = 'INFO'
+
+
+    @patch('boto3.resource')
+    @patch('boto3.client')
+    def setUp(self, mock_boto3_client, mock_boto3_resource):
+        # This setUp method is called before each test method
+        
+        # Mock DynamoDB resource and table
+        self.mock_dynamodb_resource = MagicMock()
+        self.mock_appointments_table = MagicMock()
+        self.mock_dynamodb_resource.Table.return_value = self.mock_appointments_table
+        mock_boto3_resource.return_value = self.mock_dynamodb_resource
+
+        # Mock SQS client
+        self.mock_sqs_client = MagicMock()
+        mock_boto3_client.return_value = self.mock_sqs_client
+        
+        # Re-import lambda_handler or reload its module if env vars need to be re-read by it.
+        # For this structure, it's usually fine as os.environ is dynamic.
+        # from backend.confirm_appointment_lambda import lambda_function
+        # import importlib
+        # importlib.reload(lambda_function)
+        # self.lambda_handler = lambda_function.lambda_handler
+        self.lambda_handler = lambda_handler
+
+
+    def _create_api_gateway_event(self, booking_id):
+        return {
+            "pathParameters": {
+                "id": booking_id
+            },
+            "requestContext": { # Add some typical requestContext
+                "requestId": "test-request-id",
+                "http": {
+                    "method": "POST"
+                }
+            }
+        }
+
+    def test_successful_confirmation(self):
+        booking_id = "booking123"
+        event = self._create_api_gateway_event(booking_id)
+
+        # Mock DynamoDB get_item response
+        mock_booking_item = {
+            'bookingId': booking_id,
+            'status': 'pending_confirmation',
+            'serviceId': 'serviceABC',
+            'locationId': 'locationXYZ',
+            'proposedStartTime': '2024-01-01T10:00:00Z',
+            'proposedEndTime': '2024-01-01T11:00:00Z',
+            'clientDetails': {'name': 'Test Client', 'email': 'test@example.com'}
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+
+        # Mock DynamoDB update_item response
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'confirmed', 'updatedAt': 'some-iso-time'}
+        }
+        
+        # Mock SQS send_message response
+        self.mock_sqs_client.send_message.return_value = {'MessageId': 'sqs-message-id'}
+
+        response = self.lambda_handler(event, {})
+        
+        self.assertEqual(response['statusCode'], 200)
+        response_body = json.loads(response['body'])
+        self.assertEqual(response_body['message'], f"Booking {booking_id} confirmed successfully.")
+        self.assertEqual(response_body['booking']['status'], 'confirmed')
+
+        # Assert DynamoDB calls
+        self.mock_appointments_table.get_item.assert_called_once_with(Key={'bookingId': booking_id})
+        self.mock_appointments_table.update_item.assert_called_once()
+        update_args = self.mock_appointments_table.update_item.call_args[1]
+        self.assertEqual(update_args['Key'], {'bookingId': booking_id})
+        self.assertEqual(update_args['ExpressionAttributeValues'][':status_val'], 'confirmed')
+
+        # Assert SQS calls (called twice)
+        self.assertEqual(self.mock_sqs_client.send_message.call_count, 2)
+        
+        # Check call to Google Calendar SQS
+        calendar_sqs_call = self.mock_sqs_client.send_message.call_args_list[0]
+        self.assertEqual(calendar_sqs_call[1]['QueueUrl'], 'mock_google_calendar_sqs_url')
+        calendar_message_body = json.loads(calendar_sqs_call[1]['MessageBody'])
+        self.assertEqual(calendar_message_body['bookingId'], booking_id)
+        self.assertEqual(calendar_message_body['action'], 'CREATE_EVENT')
+
+        # Check call to Notification SQS
+        notification_sqs_call = self.mock_sqs_client.send_message.call_args_list[1]
+        self.assertEqual(notification_sqs_call[1]['QueueUrl'], 'mock_notification_sqs_url')
+        notification_message_body = json.loads(notification_sqs_call[1]['MessageBody'])
+        self.assertEqual(notification_message_body['bookingId'], booking_id)
+        self.assertEqual(notification_message_body['notificationType'], 'BOOKING_CONFIRMED')
+
+
+    def test_booking_not_found(self):
+        booking_id = "booking_not_exist"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {} # No 'Item' key
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 404)
+        self.assertIn(f"Booking {booking_id} not found", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+        self.mock_sqs_client.send_message.assert_not_called()
+
+    def test_booking_already_confirmed(self):
+        booking_id = "booking_already_done"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {
+            'Item': {'bookingId': booking_id, 'status': 'confirmed'}
+        }
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 409)
+        self.assertIn(f"Booking {booking_id} cannot be confirmed. Current status: confirmed", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+
+    def test_booking_in_cancelled_status(self):
+        booking_id = "booking_cancelled_status"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {
+            'Item': {'bookingId': booking_id, 'status': 'cancelled'}
+        }
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 409)
+        self.assertIn(f"Booking {booking_id} cannot be confirmed. Current status: cancelled", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+
+    def test_dynamodb_get_item_error(self):
+        booking_id = "booking_ddb_get_error"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.side_effect = Exception("DynamoDB get_item failed")
+        
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Failed to fetch booking details.", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+
+    def test_dynamodb_update_item_error(self):
+        booking_id = "booking_ddb_update_error"
+        event = self._create_api_gateway_event(booking_id)
+        mock_booking_item = {'bookingId': booking_id, 'status': 'pending_confirmation'}
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.side_effect = Exception("DynamoDB update_item failed")
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Failed to update booking status.", response['body'])
+        # SQS messages should not be sent if DB update fails
+        self.mock_sqs_client.send_message.assert_not_called()
+
+    def test_sqs_send_calendar_message_error_still_sends_notification(self):
+        booking_id = "booking_sqs_cal_error"
+        event = self._create_api_gateway_event(booking_id)
+        mock_booking_item = {
+            'bookingId': booking_id, 'status': 'pending_confirmation',
+            'serviceId': 's1', 'locationId': 'l1', 
+            'proposedStartTime': '2024-01-01T10:00:00Z', 'proposedEndTime': '2024-01-01T11:00:00Z',
+            'clientDetails': {'name': 'Test Client', 'email': 'test@example.com'}
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'confirmed'}
+        }
+        
+        # First SQS call (calendar) fails, second (notification) succeeds
+        self.mock_sqs_client.send_message.side_effect = [
+            Exception("SQS send_message for calendar failed"), 
+            {'MessageId': 'sqs-message-id-notification'}
+        ]
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 200) # Still 200 as booking confirmed, SQS error logged
+        self.assertIn(f"Booking {booking_id} confirmed successfully", response['body'])
+        
+        self.mock_appointments_table.update_item.assert_called_once()
+        self.assertEqual(self.mock_sqs_client.send_message.call_count, 2)
+        
+        # Check that the second call was to the notification queue
+        notification_sqs_call = self.mock_sqs_client.send_message.call_args_list[1] # Second call
+        self.assertEqual(notification_sqs_call[1]['QueueUrl'], 'mock_notification_sqs_url')
+
+    def test_missing_path_parameter_id(self):
+        event = { "pathParameters": {} } # Missing 'id'
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn("Missing booking ID in request path.", response['body'])
+
+    def test_missing_environment_variables(self):
+        # Temporarily remove an environment variable
+        original_val = os.environ.pop('APPOINTMENTS_TABLE_NAME', None)
+        
+        # Need to reload the lambda_function module for it to pick up changed env vars at module level
+        # For this test, we'll assume the check is robust enough at the start of the handler.
+        # If APPOINTMENTS_TABLE_NAME is used to initialize dynamodb.Table() at global scope in lambda,
+        # this test would need more complex module reloading.
+        # Our current lambda_function.py initializes table inside handler.
+        
+        booking_id = "booking_env_error"
+        event = self._create_api_gateway_event(booking_id)
+        
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Configuration error", response['body'])
+        
+        # Restore environment variable
+        if original_val is not None:
+            os.environ['APPOINTMENTS_TABLE_NAME'] = original_val
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+
+# To run these tests:
+# Ensure you are in the project root directory.
+# python -m unittest backend.confirm_appointment_lambda.test_lambda_function
+# or if structure allows, just from root:
+# python -m unittest discover -s backend/confirm_appointment_lambda -p "test_*.py"
+# Ensure __init__.py files are present in backend and backend.confirm_appointment_lambda for discovery.
+# (No, for `python -m unittest backend.confirm_appointment_lambda.test_lambda_function` it's fine)
+# If lambda_function.py is at the root of confirm_appointment_lambda, then from root:
+# python -m unittest backend.confirm_appointment_lambda.test_lambda_function
+
+# If you have __init__.py in backend/ and backend/confirm_appointment_lambda/
+# you can run from project root:
+# python -m unittest backend.confirm_appointment_lambda.test_lambda_function
+# Make sure PYTHONPATH includes the project root or that the IDE handles it.
+# For example, if project root is /path/to/project, then
+# PYTHONPATH=/path/to/project python -m unittest backend.confirm_appointment_lambda.test_lambda_function
+# Or, more simply, `cd` into the `backend` directory and run:
+# python -m unittest confirm_appointment_lambda.test_lambda_function
+# Or, `cd` into `backend/confirm_appointment_lambda` and run:
+# python -m unittest test_lambda_function
+# Best practice is usually to run from project root with proper module paths.
+
+# Assuming standard project structure where 'backend' is a top-level package:
+# (Project Root)
+# |-- backend
+# |   |-- __init__.py (optional, for older Python or namespace pkg)
+# |   |-- confirm_appointment_lambda
+# |   |   |-- __init__.py (make this a package)
+# |   |   |-- lambda_function.py
+# |   |   |-- test_lambda_function.py
+# |   |   |-- requirements.txt
+# |   |-- handle_cancellation_lambda
+# |   |   |-- __init__.py (make this a package)
+# |   |   |-- lambda_function.py
+# |   |   |-- test_lambda_function.py (to be created)
+
+# To run from project root:
+# PYTHONPATH=. python -m unittest backend.confirm_appointment_lambda.test_lambda_function
+# The PYTHONPATH=. tells Python to look for modules in the current directory.
+# Or, if your test runner (like VSCode's test explorer) is configured correctly, it should just work.
+# For pytest, it generally handles paths better automatically.
+# pytest backend/confirm_appointment_lambda/test_lambda_function.py

--- a/backend/google_calendar_sync_lambda/lambda_function.py
+++ b/backend/google_calendar_sync_lambda/lambda_function.py
@@ -2,178 +2,422 @@ import json
 import logging
 import os
 import boto3
-from google.oauth2 import service_account # Adjusted import
-from googleapiclient import discovery # Adjusted import
+import datetime
+import uuid # For generating dummy event IDs
 
 # Initialize logger
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
-# Environment variables for secrets
-# GOOGLE_CREDS_SECRET_NAME = os.environ.get('GOOGLE_CREDS_SECRET_NAME')
-# dynamodb = boto3.resource('dynamodb') # Example if needed for booking details
-# appointments_table_name = os.environ.get('APPOINTMENTS_TABLE_NAME')
-# locations_table_name = os.environ.get('LOCATIONS_TABLE_NAME')
+# Initialize Boto3 clients
+dynamodb = boto3.resource('dynamodb')
 
-# Global variable for Google Calendar service client (initialized once per container)
-# GOOGLE_CALENDAR_SERVICE = None
+# Environment variables for table names
+APPOINTMENTS_TABLE_NAME = os.environ.get('APPOINTMENTS_TABLE_NAME')
+SERVICES_TABLE_NAME = os.environ.get('SERVICES_TABLE_NAME')
+LOCATIONS_TABLE_NAME = os.environ.get('LOCATIONS_TABLE_NAME')
 
-def get_google_calendar_service():
+# --- Stubbed Google Calendar API Functions ---
+def stub_create_google_calendar_event(calendar_id, event_title, event_description, start_time_iso, end_time_iso):
     """
-    Placeholder function to simulate fetching credentials and building the Google Calendar service.
-    In a real scenario, this would fetch credentials from AWS Secrets Manager.
+    Stub function to simulate creating a Google Calendar event.
+    Logs parameters and returns a dummy event ID.
     """
-    # global GOOGLE_CALENDAR_SERVICE
-    # if GOOGLE_CALENDAR_SERVICE:
-    #     return GOOGLE_CALENDAR_SERVICE
-
-    logger.info("Attempting to get Google Calendar service.")
-    logger.info("This would typically involve: ")
-    logger.info("1. Fetching Google API credentials (e.g., service account JSON) from AWS Secrets Manager.")
-    logger.info("2. Using google.oauth2.service_account.Credentials.from_service_account_info().")
-    logger.info("3. Building the service client using googleapiclient.discovery.build().")
+    logger.info(f"[STUB] Creating Google Calendar event in calendar '{calendar_id}'")
+    logger.info(f"[STUB] Event Title: {event_title}")
+    logger.info(f"[STUB] Event Description: {event_description}")
+    logger.info(f"[STUB] Start Time: {start_time_iso}")
+    logger.info(f"[STUB] End Time: {end_time_iso}")
     
-    # TODO: Retrieve Google Calendar API credentials from AWS Secrets Manager
-    # try:
-    #     secrets_manager = boto3.client('secretsmanager')
-    #     secret_value = secrets_manager.get_secret_value(SecretId=GOOGLE_CREDS_SECRET_NAME)
-    #     credentials_info = json.loads(secret_value['SecretString'])
-    #
-    #     credentials = service_account.Credentials.from_service_account_info(
-    #         credentials_info,
-    #         scopes=['https://www.googleapis.com/auth/calendar']
-    #     )
-    #     GOOGLE_CALENDAR_SERVICE = discovery.build('calendar', 'v3', credentials=credentials)
-    #     logger.info("Google Calendar service client initialized successfully.")
-    #     return GOOGLE_CALENDAR_SERVICE
-    # except Exception as e:
-    #     logger.error(f"Error initializing Google Calendar service: {e}", exc_info=True)
-    #     return None
-    return None # Placeholder for now
+    # Simulate API call delay (optional)
+    # import time
+    # time.sleep(0.1) 
+    
+    dummy_event_id = f"stub_event_{uuid.uuid4()}"
+    logger.info(f"[STUB] Google Calendar event created successfully. Event ID: {dummy_event_id}")
+    return dummy_event_id
 
-def handle_check_availability(data, calendar_service):
-    logger.info("Handling check_availability")
-    logger.info(f"Received data: {json.dumps(data)}")
-    # TODO: Implement logic to check free/busy slots using calendar_service
-    # Example:
-    # calendar_id = data.get('calendarId', 'primary')
-    # time_min = data.get('timeMin') # ISO format
-    # time_max = data.get('timeMax') # ISO format
-    # items_to_check = [{"id": calendar_id}]
-    # if calendar_service and time_min and time_max:
-    #     freebusy_query = {
-    #         "timeMin": time_min,
-    #         "timeMax": time_max,
-    #         "items": items_to_check
-    #     }
-    #     freebusy_result = calendar_service.freebusy().query(body=freebusy_query).execute()
-    #     # Process freebusy_result to find available slots
-    #     return {"status": "success", "action": "check_availability", "slots": freebusy_result.get('calendars', {}).get(calendar_id, {}).get('busy', [])}
-    # else:
-    #     logger.warning("Calendar service not available or missing timeMin/timeMax for check_availability.")
-    return {"status": "success", "action": "check_availability", "slots": ["Dummy slot 1", "Dummy slot 2"]}
+def stub_delete_google_calendar_event(calendar_id, event_id):
+    """
+    Stub function to simulate deleting a Google Calendar event.
+    Logs parameters and returns a success status.
+    """
+    logger.info(f"[STUB] Deleting Google Calendar event '{event_id}' from calendar '{calendar_id}'")
+    # Simulate API call delay (optional)
+    # import time
+    # time.sleep(0.1)
+    logger.info(f"[STUB] Google Calendar event '{event_id}' deleted successfully.")
+    return True
+# --- End Stubbed Functions ---
 
-def handle_create_event(data, calendar_service):
-    logger.info("Handling create_event")
-    logger.info(f"Received data: {json.dumps(data)}")
-    # TODO: Implement logic to create Google Calendar event using calendar_service
-    # Example:
-    # calendar_id = data.get('calendarId', 'primary')
-    # event_body = data.get('eventBody') # e.g., summary, start, end, attendees
-    # if calendar_service and event_body:
-    #     created_event = calendar_service.events().insert(calendarId=calendar_id, body=event_body).execute()
-    #     return {"status": "success", "action": "create_event", "eventId": created_event.get('id')}
-    # else:
-    #     logger.warning("Calendar service not available or missing eventBody for create_event.")
-    return {"status": "success", "action": "create_event", "eventId": "dummy_event_id_123"}
+def handle_create_event_sqs(message_data):
+    """
+    Handles the CREATE_EVENT action from an SQS message.
+    """
+    lambda_name = "GoogleCalendarSyncLambda"
+    booking_id = message_data.get('bookingId')
+    logger.info(f"[{lambda_name}-CREATE_EVENT] Processing for bookingId: {booking_id}")
 
-def handle_update_event(data, calendar_service):
-    logger.info("Handling update_event")
-    logger.info(f"Received data: {json.dumps(data)}")
-    # TODO: Implement logic to update Google Calendar event using calendar_service
-    # Example:
-    # calendar_id = data.get('calendarId', 'primary')
-    # event_id = data.get('eventId')
-    # event_body_updates = data.get('eventBodyUpdates')
-    # if calendar_service and event_id and event_body_updates:
-    #     updated_event = calendar_service.events().patch(calendarId=calendar_id, eventId=event_id, body=event_body_updates).execute()
-    #     return {"status": "success", "action": "update_event", "eventId": updated_event.get('id')}
-    # else:
-    #     logger.warning("Calendar service not available or missing eventId/eventBodyUpdates for update_event.")
-    return {"status": "success", "action": "update_event", "eventId": data.get('eventId')}
+    required_fields = ['serviceId', 'locationId', 'proposedStartTime', 'proposedEndTime', 
+                       'clientName', 'clientEmail'] # clientContact renamed to clientEmail for clarity
+    for field in required_fields:
+        if field not in message_data:
+            logger.error(f"[{lambda_name}-CREATE_EVENT] Missing required field '{field}' in message for bookingId: {booking_id}")
+            raise ValueError(f"Missing required field: {field}")
 
-def handle_delete_event(data, calendar_service):
-    logger.info("Handling delete_event")
-    logger.info(f"Received data: {json.dumps(data)}")
-    # TODO: Implement logic to delete Google Calendar event using calendar_service
-    # Example:
-    # calendar_id = data.get('calendarId', 'primary')
-    # event_id = data.get('eventId')
-    # if calendar_service and event_id:
-    #     calendar_service.events().delete(calendarId=calendar_id, eventId=event_id).execute()
-    #     return {"status": "success", "action": "delete_event", "eventId": event_id}
-    # else:
-    #     logger.warning("Calendar service not available or missing eventId for delete_event.")
-    return {"status": "success", "action": "delete_event", "eventId": data.get('eventId')}
+    service_id = message_data['serviceId']
+    location_id = message_data['locationId']
+    proposed_start_time = message_data['proposedStartTime']
+    proposed_end_time = message_data['proposedEndTime']
+    client_name = message_data['clientName']
+    client_email = message_data['clientEmail'] # Assuming clientContact is email
+    notes = message_data.get('notes', '') # Optional field
+
+    # 1. Fetch service details
+    try:
+        services_table = dynamodb.Table(SERVICES_TABLE_NAME)
+        service_response = services_table.get_item(Key={'serviceId': service_id})
+        service_item = service_response.get('Item')
+        if not service_item:
+            logger.error(f"[{lambda_name}-CREATE_EVENT] Service {service_id} not found for bookingId: {booking_id}.")
+            raise ValueError(f"Service details not found for serviceId: {service_id}")
+        service_name = service_item.get('serviceName', 'Unknown Service')
+    except Exception as e:
+        logger.error(f"[{lambda_name}-CREATE_EVENT] Error fetching service {service_id} for booking {booking_id}: {e}", exc_info=True)
+        raise
+
+    # 2. Fetch location details
+    try:
+        locations_table = dynamodb.Table(LOCATIONS_TABLE_NAME)
+        location_response = locations_table.get_item(Key={'locationId': location_id})
+        location_item = location_response.get('Item')
+        if not location_item:
+            logger.error(f"[{lambda_name}-CREATE_EVENT] Location {location_id} not found for bookingId: {booking_id}.")
+            raise ValueError(f"Location details not found for locationId: {location_id}")
+        location_name = location_item.get('locationName', 'Unknown Location')
+        google_calendar_id_for_location = location_item.get('googleCalendarId')
+        if not google_calendar_id_for_location:
+            logger.error(f"[{lambda_name}-CREATE_EVENT] googleCalendarId not configured for location {location_id} (booking {booking_id}).")
+            raise ValueError(f"googleCalendarId missing for location: {location_id}")
+    except Exception as e:
+        logger.error(f"[{lambda_name}-CREATE_EVENT] Error fetching location {location_id} for booking {booking_id}: {e}", exc_info=True)
+        raise
+
+    # 3. Construct event details
+    event_title = f"Appointment: {service_name} for {client_name}"
+    event_description = (
+        f"Service: {service_name}\n"
+        f"Client: {client_name}\n"
+        f"Email: {client_email}\n"
+        f"Location: {location_name}\n"
+        f"Notes: {notes if notes else 'N/A'}\n"
+        f"Booking ID: {booking_id}"
+    )
+
+    # 4. Call (stubbed) Google Calendar API to create event
+    try:
+        google_event_id = stub_create_google_calendar_event(
+            calendar_id=google_calendar_id_for_location,
+            event_title=event_title,
+            event_description=event_description,
+            start_time_iso=proposed_start_time,
+            end_time_iso=proposed_end_time
+        )
+    except Exception as e: # Catch errors from the stub, though unlikely for a simple stub
+        logger.error(f"[{lambda_name}-CREATE_EVENT] Error creating Google Calendar event (stub) for booking {booking_id}: {e}", exc_info=True)
+        raise
+
+    # 5. Update AppointmentsTable with googleCalendarEventId
+    if google_event_id:
+        try:
+            appointments_table = dynamodb.Table(APPOINTMENTS_TABLE_NAME)
+            updated_at = datetime.datetime.utcnow().isoformat()
+            appointments_table.update_item(
+                Key={'bookingId': booking_id},
+                UpdateExpression="SET googleCalendarEventId = :gcal_id, updatedAt = :ua",
+                ExpressionAttributeValues={
+                    ':gcal_id': google_event_id,
+                    ':ua': updated_at
+                }
+            )
+            logger.info(f"[{lambda_name}-CREATE_EVENT] Booking {booking_id} updated with googleCalendarEventId: {google_event_id}")
+        except Exception as e:
+            logger.error(f"[{lambda_name}-CREATE_EVENT] Error updating booking {booking_id} with googleCalendarEventId: {e}", exc_info=True)
+            # This is a critical error if the event was created but not linked. Consider retry or DLQ.
+            raise
+    else:
+        # Should not happen with the current stub, but good practice for real API
+        logger.error(f"[{lambda_name}-CREATE_EVENT] Failed to get googleCalendarEventId for booking {booking_id} from stub.")
+        raise Exception("Failed to obtain Google Calendar Event ID from stub.")
+
+
+def handle_delete_event_sqs(message_data):
+    """
+    Handles the DELETE_EVENT action from an SQS message.
+    """
+    lambda_name = "GoogleCalendarSyncLambda"
+    booking_id = message_data.get('bookingId') # For logging
+    logger.info(f"[{lambda_name}-DELETE_EVENT] Processing for bookingId: {booking_id}")
+
+    required_fields = ['googleCalendarEventId', 'locationId']
+    for field in required_fields:
+        if field not in message_data:
+            logger.error(f"[{lambda_name}-DELETE_EVENT] Missing required field '{field}' in message for bookingId: {booking_id}")
+            raise ValueError(f"Missing required field: {field}")
+
+    google_event_id_to_delete = message_data['googleCalendarEventId']
+    location_id = message_data['locationId']
+
+    # 1. Fetch location details for googleCalendarId
+    try:
+        locations_table = dynamodb.Table(LOCATIONS_TABLE_NAME)
+        location_response = locations_table.get_item(Key={'locationId': location_id})
+        location_item = location_response.get('Item')
+        if not location_item:
+            logger.error(f"[{lambda_name}-DELETE_EVENT] Location {location_id} not found for bookingId: {booking_id}.")
+            raise ValueError(f"Location details not found for locationId: {location_id}")
+        google_calendar_id_for_location = location_item.get('googleCalendarId')
+        if not google_calendar_id_for_location:
+            logger.error(f"[{lambda_name}-DELETE_EVENT] googleCalendarId not configured for location {location_id} (booking {booking_id}).")
+            raise ValueError(f"googleCalendarId missing for location: {location_id}")
+    except Exception as e:
+        logger.error(f"[{lambda_name}-DELETE_EVENT] Error fetching location {location_id} for booking {booking_id}: {e}", exc_info=True)
+        raise
+
+    # 2. Call (stubbed) Google Calendar API to delete event
+    try:
+        stub_delete_google_calendar_event(
+            calendar_id=google_calendar_id_for_location,
+            event_id=google_event_id_to_delete
+        )
+        logger.info(f"[{lambda_name}-DELETE_EVENT] Successfully processed delete for event {google_event_id_to_delete} in booking {booking_id}.")
+    except Exception as e: # Catch errors from the stub
+        logger.error(f"[{lambda_name}-DELETE_EVENT] Error deleting Google Calendar event (stub) {google_event_id_to_delete} for booking {booking_id}: {e}", exc_info=True)
+        raise
+
 
 def lambda_handler(event, context):
     """
-    Main Lambda handler for Google Calendar synchronization.
-    Dispatches actions based on the 'action' field in the event.
-    Event structure example:
-    {
-        "action": "create_event",
-        "data": {
-            "calendarId": "primary",
-            "eventBody": {
-                "summary": "New Appointment",
-                "start": {"dateTime": "2024-08-15T10:00:00Z", "timeZone": "UTC"},
-                "end": {"dateTime": "2024-08-15T11:00:00Z", "timeZone": "UTC"}
-            }
-        }
-    }
+    Main Lambda handler for Google Calendar synchronization from SQS.
+    Processes messages from an SQS queue.
     """
     lambda_name = "GoogleCalendarSyncLambda"
-    logger.info(f"Received event for {lambda_name}: {json.dumps(event)}")
+    logger.info(f"Received SQS event for {lambda_name}: {json.dumps(event)}")
 
-    try:
-        # TODO: Initialize Google Calendar service client
-        # This should ideally be done once globally or managed carefully.
-        calendar_service = get_google_calendar_service()
-        # if not calendar_service:
-        #     logger.error("Failed to initialize Google Calendar service.")
-        #     return {
-        #         "statusCode": 500,
-        #         "body": json.dumps({"error": "Internal server error: Could not connect to Google Calendar."})
-        #     }
+    if not all([APPOINTMENTS_TABLE_NAME, SERVICES_TABLE_NAME, LOCATIONS_TABLE_NAME]):
+        logger.fatal(f"[{lambda_name}] Missing one or more critical environment variables for table names. Exiting.")
+        # This is a configuration error, returning error to SQS might cause infinite retries if not handled by DLQ.
+        # For Lambda, raising an exception after logging is often the best way to signal failure.
+        raise EnvironmentError("Missing critical table name environment variables.")
 
-        action = event.get('action')
-        event_data = event.get('data', {})
+    processed_messages = 0
+    failed_messages = 0
 
-        response_body = {}
-        if action == 'check_availability':
-            response_body = handle_check_availability(event_data, calendar_service)
-        elif action == 'create_event':
-            response_body = handle_create_event(event_data, calendar_service)
-        elif action == 'update_event':
-            response_body = handle_update_event(event_data, calendar_service)
-        elif action == 'delete_event':
-            response_body = handle_delete_event(event_data, calendar_service)
-        else:
-            logger.warning(f"Unknown action: {action}")
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"error": f"Unknown action: {action}"})
+    for record in event.get('Records', []):
+        try:
+            message_body_str = record.get('body')
+            if not message_body_str:
+                logger.error(f"[{lambda_name}] SQS record missing 'body'. Record: {record}")
+                failed_messages += 1
+                continue 
+            
+            logger.info(f"[{lambda_name}] Raw SQS message body: {message_body_str}")
+            message_data = json.loads(message_body_str)
+            
+            action = message_data.get('action')
+            booking_id_log = message_data.get('bookingId', 'UnknownBookingID') # For logging before action dispatch
+
+            logger.info(f"[{lambda_name}] Processing action '{action}' for bookingId: {booking_id_log}")
+
+            if action == 'CREATE_EVENT':
+                handle_create_event_sqs(message_data)
+            elif action == 'DELETE_EVENT':
+                handle_delete_event_sqs(message_data)
+            else:
+                logger.warning(f"[{lambda_name}] Unknown action '{action}' in SQS message for bookingId {booking_id_log}. Message: {json.dumps(message_data)}")
+                failed_messages += 1
+                continue # Skip to next message
+            
+            processed_messages += 1
+            # If partial batch processing fails, SQS will retry the whole batch by default.
+            # Successful messages in a batch should ideally be idempotent or handled carefully.
+
+        except json.JSONDecodeError as e:
+            logger.error(f"[{lambda_name}] Failed to decode JSON from SQS message body: {message_body_str}. Error: {e}", exc_info=True)
+            failed_messages += 1
+        except ValueError as e: # For missing fields or data validation errors
+            logger.error(f"[{lambda_name}] Data validation error processing SQS message: {e}. Message body: {message_body_str}", exc_info=True)
+            failed_messages += 1
+        except Exception as e: # Catch-all for other unexpected errors during processing of a single message
+            logger.error(f"[{lambda_name}] Unexpected error processing SQS message: {e}. Message body: {message_body_str}", exc_info=True)
+            failed_messages += 1
+            # Depending on SQS configuration, this might lead to retries for the message.
+
+    logger.info(f"[{lambda_name}] Processing complete. Processed: {processed_messages}, Failed: {failed_messages}.")
+
+    # For SQS, if any message fails, you might want the Lambda invocation to fail to leverage SQS retry/DLQ.
+    # However, standard behavior is that if the handler completes without an exception, SQS considers the batch successful.
+    # To signal SQS to retry the entire batch (if ReportBatchItemFailures is not configured on the event source mapping),
+    # an exception should be raised if failed_messages > 0.
+    # If ReportBatchItemFailures is enabled, then failed messages are returned in a specific format.
+    # For simplicity here, we'll log failures. The SQS trigger configuration (batch size, retries, DLQ) is key.
+    
+    # This lambda currently doesn't return a body, which is fine for SQS triggers if no batch item failure reporting is used.
+    # If batch item failure reporting *is* used, the return value needs to be:
+    # { "batchItemFailures": [ { "itemIdentifier": "messageIdOfFailedMessage" }, ... ] }
+    # For now, assuming no batch item failure reporting or that DLQ handles persistent errors.
+    return {
+        "status": "completed",
+        "processed_messages": processed_messages,
+        "failed_messages": failed_messages
+    }
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    
+    # Setup mock environment variables for local testing
+    os.environ['APPOINTMENTS_TABLE_NAME'] = "MockAppointmentsTable"
+    os.environ['SERVICES_TABLE_NAME'] = "MockServicesTable"
+    os.environ['LOCATIONS_TABLE_NAME'] = "MockLocationsTable"
+
+    # Mock Boto3 resources/tables for local testing
+    class MockDynamoDBTable:
+        def __init__(self, table_name):
+            self.table_name = table_name
+            self.mock_data = {} # Store mock data here if needed for get_item
+
+        def get_item(self, Key):
+            logger.info(f"[MockDynamoDBTable-{self.table_name}] get_item called with Key: {Key}")
+            if self.table_name == "MockServicesTable" and Key['serviceId'] == "service123":
+                return {"Item": {"serviceId": "service123", "serviceName": "Test Service", "durationMinutes": 60}}
+            if self.table_name == "MockLocationsTable" and Key['locationId'] == "locationABC":
+                return {"Item": {"locationId": "locationABC", "locationName": "Main Street Clinic", "googleCalendarId": "clinic_main_st@group.calendar.google.com"}}
+            if self.table_name == "MockLocationsTable" and Key['locationId'] == "locationXYZ_no_gcal":
+                 return {"Item": {"locationId": "locationXYZ_no_gcal", "locationName": "Downtown Branch"}} # No googleCalendarId
+            return {"Item": None} # Default to not found
+
+        def update_item(self, Key, UpdateExpression, ExpressionAttributeValues):
+            logger.info(f"[MockDynamoDBTable-{self.table_name}] update_item called for Key: {Key} with Updates: {ExpressionAttributeValues}")
+            return {"Attributes": {"bookingId": Key['bookingId'], **ExpressionAttributeValues}}
+
+    # Monkey patch boto3.resource for local testing
+    _original_boto3_resource = boto3.resource
+    def mock_boto3_resource(service_name):
+        if service_name == 'dynamodb':
+            class MockDynamoDBResource:
+                def Table(self, table_name):
+                    return MockDynamoDBTable(table_name)
+            return MockDynamoDBResource()
+        return _original_boto3_resource(service_name)
+    boto3.resource = mock_boto3_resource
+    # Re-initialize global dynamodb client with mock after patching
+    dynamodb = boto3.resource('dynamodb')
+
+
+    # Test SQS CREATE_EVENT
+    test_sqs_event_create = {
+        "Records": [
+            {
+                "messageId": "msg1",
+                "receiptHandle": "handle1",
+                "body": json.dumps({
+                    "action": "CREATE_EVENT",
+                    "bookingId": "booking789",
+                    "serviceId": "service123",
+                    "locationId": "locationABC",
+                    "proposedStartTime": "2024-09-01T10:00:00Z",
+                    "proposedEndTime": "2024-09-01T11:00:00Z",
+                    "clientName": "John Doe",
+                    "clientEmail": "john.doe@example.com",
+                    "notes": "Prefers morning appointments."
+                }),
+                "attributes": {}, "messageAttributes": {}, "md5OfBody": "", "eventSource": "aws:sqs", "eventSourceARN": "", "awsRegion": "us-east-1"
             }
-        
-        return {
-            "statusCode": 200,
-            "headers": {"Content-Type": "application/json"},
-            "body": json.dumps(response_body)
-        }
+        ]
+    }
+    print("\n--- Testing SQS CREATE_EVENT ---")
+    response = lambda_handler(test_sqs_event_create, {})
+    print(json.dumps(response, indent=2))
 
-    except Exception as e:
-        logger.error(f"Error processing {lambda_name} request: {e}", exc_info=True)
+    # Test SQS DELETE_EVENT
+    test_sqs_event_delete = {
+        "Records": [
+            {
+                "messageId": "msg2",
+                "receiptHandle": "handle2",
+                "body": json.dumps({
+                    "action": "DELETE_EVENT",
+                    "bookingId": "booking456", # For logging context
+                    "googleCalendarEventId": "evt_some_google_id_to_delete",
+                    "locationId": "locationABC"
+                }),
+                "attributes": {}, "messageAttributes": {}, "md5OfBody": "", "eventSource": "aws:sqs", "eventSourceARN": "", "awsRegion": "us-east-1"
+            }
+        ]
+    }
+    print("\n--- Testing SQS DELETE_EVENT ---")
+    response = lambda_handler(test_sqs_event_delete, {})
+    print(json.dumps(response, indent=2))
+
+    # Test SQS UNKNOWN_ACTION
+    test_sqs_event_unknown = {
+         "Records": [
+            {
+                "messageId": "msg3",
+                "body": json.dumps({"action": "SOME_OTHER_ACTION", "bookingId": "booking111"}),
+            }
+        ]
+    }
+    print("\n--- Testing SQS UNKNOWN_ACTION ---")
+    response = lambda_handler(test_sqs_event_unknown, {})
+    print(json.dumps(response, indent=2))
+    
+    # Test SQS message with missing required field for CREATE_EVENT
+    test_sqs_create_missing_field = {
+        "Records": [
+            {
+                "messageId": "msg4",
+                "body": json.dumps({
+                    "action": "CREATE_EVENT", # Missing serviceId
+                    "bookingId": "booking000",
+                    "locationId": "locationABC",
+                    "proposedStartTime": "2024-09-01T10:00:00Z",
+                    "proposedEndTime": "2024-09-01T11:00:00Z",
+                    "clientName": "Jane Doe",
+                    "clientEmail": "jane.doe@example.com"
+                }),
+            }
+        ]
+    }
+    print("\n--- Testing SQS CREATE_EVENT (Missing Field) ---")
+    response = lambda_handler(test_sqs_create_missing_field, {})
+    print(json.dumps(response, indent=2))
+
+    # Test SQS message with location missing googleCalendarId for CREATE_EVENT
+    test_sqs_create_missing_gcal_id = {
+        "Records": [
+            {
+                "messageId": "msg5",
+                "body": json.dumps({
+                    "action": "CREATE_EVENT",
+                    "bookingId": "booking001",
+                    "serviceId": "service123",
+                    "locationId": "locationXYZ_no_gcal", # This location mock has no googleCalendarId
+                    "proposedStartTime": "2024-09-01T10:00:00Z",
+                    "proposedEndTime": "2024-09-01T11:00:00Z",
+                    "clientName": "Jim Doe",
+                    "clientEmail": "jim.doe@example.com"
+                }),
+            }
+        ]
+    }
+    print("\n--- Testing SQS CREATE_EVENT (Location missing googleCalendarId) ---")
+    response = lambda_handler(test_sqs_create_missing_gcal_id, {})
+    print(json.dumps(response, indent=2))
+
+    # Restore original boto3.resource
+    boto3.resource = _original_boto3_resource
         return {
             "statusCode": 500,
             "headers": {"Content-Type": "application/json"},

--- a/backend/handle_cancellation_lambda/lambda_function.py
+++ b/backend/handle_cancellation_lambda/lambda_function.py
@@ -7,62 +7,175 @@ import boto3
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
-# Initialize Boto3 clients (e.g., for DynamoDB, SQS, SNS)
-# dynamodb = boto3.resource('dynamodb')
-# appointments_table_name = os.environ.get('APPOINTMENTS_TABLE_NAME')
-# notification_sqs_url = os.environ.get('NOTIFICATION_SQS_URL') # Or SNS topic ARN
+import datetime
+
+# Initialize Boto3 clients
+dynamodb = boto3.resource('dynamodb')
+sqs = boto3.client('sqs')
+
+appointments_table_name = os.environ.get('APPOINTMENTS_TABLE_NAME')
+notification_sqs_url = os.environ.get('NOTIFICATION_SQS_URL')
+google_calendar_sync_sqs_url = os.environ.get('GOOGLE_CALENDAR_SYNC_SQS_URL') # Added for Google Calendar integration
 
 def lambda_handler(event, context):
     """
     Handles incoming requests for the HandleCancellationLambda.
-    Could be triggered by API Gateway (e.g., POST /bookings/{id}/cancel)
-    or from an SQS message if cancellation is part of a workflow.
+    Triggered by API Gateway (e.g., POST /bookings/{id}/cancel).
     """
     lambda_name = "HandleCancellationLambda"
     logger.info(f"Received event for {lambda_name}: {json.dumps(event)}")
 
+    # Check for required environment variables
+    if not all([appointments_table_name, notification_sqs_url, google_calendar_sync_sqs_url]):
+        logger.error("Missing one or more environment variables: APPOINTMENTS_TABLE_NAME, NOTIFICATION_SQS_URL, GOOGLE_CALENDAR_SYNC_SQS_URL")
+        return {
+            "statusCode": 500,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"error": f"Configuration error in {lambda_name}."})
+        }
+    
+    appointments_table = dynamodb.Table(appointments_table_name)
+
     try:
-        # TODO: Implement HandleCancellationLambda logic
-        # 1. Extract bookingId from event (e.g., pathParameters or message body).
-        # 2. Validate the bookingId.
-        # 3. Fetch the booking from DynamoDB (AppointmentsTable).
-        # 4. Check if the booking can be cancelled (e.g., based on status or cancellation window).
-        # 5. Update the booking status to 'cancelled' in DynamoDB.
-        # 6. If synced with Google Calendar, delete/update the calendar event.
-        # 7. Send a notification to the client about the cancellation (e.g., via SQS to NotificationLambda or directly to SNS).
-        # 8. Send a notification to staff if necessary.
-
-        # Placeholder response
-        response_message = f"{lambda_name} executed successfully. Implementation pending."
+        # 1. Extract bookingId
+        if 'pathParameters' in event and event['pathParameters'] and 'id' in event['pathParameters']:
+            booking_id = event['pathParameters']['id']
+        else:
+            logger.warning("Booking ID not found in event pathParameters.")
+            return {
+                "statusCode": 400,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": "Missing booking ID in request path."})
+            }
         
-        # Example: Extracting bookingId from path parameters (if API Gateway triggered)
-        # if 'pathParameters' in event and event['pathParameters'] and 'id' in event['pathParameters']:
-        #     booking_id = event['pathParameters']['id']
-        #     logger.info(f"Booking ID to cancel: {booking_id}")
-        # else:
-        #     # Or extract from event body if it's a different trigger source
-        #     # body = json.loads(event.get('body', '{}'))
-        #     # booking_id = body.get('bookingId')
-        #     logger.warning("Booking ID not found in pathParameters.")
-        #     # return {
-        #     #     "statusCode": 400,
-        #     #     "body": json.dumps({"error": "Missing booking ID."})
-        #     # }
+        logger.info(f"Attempting to cancel booking: {booking_id}")
+
+        # 2. Fetch the booking from DynamoDB
+        try:
+            response = appointments_table.get_item(Key={'bookingId': booking_id})
+            booking_item = response.get('Item')
+        except Exception as e:
+            logger.error(f"Error fetching booking {booking_id} from DynamoDB: {e}", exc_info=True)
+            return {
+                "statusCode": 500,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": "Failed to fetch booking details."})
+            }
+
+        # 3. Validate the booking
+        if not booking_item:
+            logger.warning(f"Booking {booking_id} not found.")
+            return {
+                "statusCode": 404,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": f"Booking {booking_id} not found."})
+            }
+
+        current_status = booking_item.get('status')
+        if current_status in ['cancelled', 'rejected', 'completed']: # Add other terminal statuses as needed
+            logger.warning(f"Booking {booking_id} is already in a terminal status: '{current_status}'. Cannot cancel again.")
+            return {
+                "statusCode": 409, # Conflict
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": f"Booking {booking_id} cannot be cancelled. Current status: {current_status}."})
+            }
+        
+        # 4. Update the booking status to 'cancelled'
+        # For now, status is always 'cancelled'. If logic for 'rejected' vs 'cancelled' is needed based on event body:
+        # new_status = "cancelled" 
+        # if 'body' in event and event['body']:
+        #    try:
+        #        body = json.loads(event['body'])
+        #        if body.get('action') == 'reject':
+        #            new_status = 'rejected'
+        #    except json.JSONDecodeError:
+        #        logger.warning("Could not parse body for action field.")
+        new_status = "cancelled" # As per instruction, stick to 'cancelled'
+        updated_at = datetime.datetime.utcnow().isoformat()
+
+        try:
+            update_response = appointments_table.update_item(
+                Key={'bookingId': booking_id},
+                UpdateExpression="SET #status = :status_val, #updatedAt = :updatedAt_val",
+                ExpressionAttributeNames={
+                    '#status': 'status',
+                    '#updatedAt': 'updatedAt'
+                },
+                ExpressionAttributeValues={
+                    ':status_val': new_status,
+                    ':updatedAt_val': updated_at
+                },
+                ReturnValues="ALL_NEW" 
+            )
+            cancelled_booking = update_response.get('Attributes', {})
+            logger.info(f"Booking {booking_id} status updated to {new_status}. Details: {json.dumps(cancelled_booking)}")
+        except Exception as e:
+            logger.error(f"Error updating booking {booking_id} status in DynamoDB: {e}", exc_info=True)
+            return {
+                "statusCode": 500,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"error": "Failed to update booking status."})
+            }
+
+        # 5. If synced with Google Calendar, send message to delete the event
+        google_calendar_event_id = booking_item.get('googleCalendarEventId')
+        if google_calendar_event_id:
+            calendar_message_body = {
+                "bookingId": booking_id,
+                "googleCalendarEventId": google_calendar_event_id,
+                "action": "DELETE_EVENT" 
+            }
+            try:
+                sqs.send_message(
+                    QueueUrl=google_calendar_sync_sqs_url,
+                    MessageBody=json.dumps(calendar_message_body)
+                )
+                logger.info(f"Sent message to Google Calendar Sync SQS for booking {booking_id} to delete event {google_calendar_event_id}: {json.dumps(calendar_message_body)}")
+            except Exception as e:
+                logger.error(f"Error sending message to Google Calendar Sync SQS for booking {booking_id}: {e}", exc_info=True)
+                # Log error, but don't fail the whole cancellation if this SQS message fails.
+                # Consider a retry mechanism or dead-letter queue for this.
+
+        # 6. Send a notification to the client about the cancellation
+        client_details = booking_item.get("clientDetails", {})
+        notification_message_body = {
+            "bookingId": booking_id,
+            "notificationType": "BOOKING_CANCELLED", # Or "BOOKING_REJECTED" if new_status logic is expanded
+            "recipient": client_details.get("email"), # Or phone, depending on notification preferences
+            "messageDetails": {
+                "clientName": client_details.get("name"),
+                "serviceName": booking_item.get("serviceName", "the service"), 
+                "startTime": booking_item.get("proposedStartTime"),
+                "reason": "Your booking has been cancelled." # Generic reason
+            }
+        }
+        if client_details.get("email"): # Only send if email is available
+            try:
+                sqs.send_message(
+                    QueueUrl=notification_sqs_url,
+                    MessageBody=json.dumps(notification_message_body)
+                )
+                logger.info(f"Sent message to Notification SQS for booking {booking_id}: {json.dumps(notification_message_body)}")
+            except Exception as e:
+                logger.error(f"Error sending message to Notification SQS for booking {booking_id}: {e}", exc_info=True)
+                # Log error, but booking is already cancelled in DB.
+        else:
+            logger.warning(f"No recipient email found for booking {booking_id}, skipping cancellation notification.")
 
 
-        logger.info(response_message)
+        # 7. Return success response
+        logger.info(f"Booking {booking_id} cancelled successfully.")
         return {
             "statusCode": 200,
-            "headers": {
-                "Content-Type": "application/json"
-            },
+            "headers": {"Content-Type": "application/json"},
             "body": json.dumps({
-                "message": response_message
+                "message": f"Booking {booking_id} cancelled successfully.",
+                "booking": cancelled_booking
             })
         }
 
-    except Exception as e:
-        logger.error(f"Error processing {lambda_name} request: {e}", exc_info=True)
+    except Exception as e: # Catch-all for any other unexpected errors
+        logger.error(f"Unexpected error in {lambda_name} for bookingId {event.get('pathParameters',{}).get('id', 'N/A')}: {e}", exc_info=True)
         return {
             "statusCode": 500,
             "headers": {

--- a/backend/handle_cancellation_lambda/test_lambda_function.py
+++ b/backend/handle_cancellation_lambda/test_lambda_function.py
@@ -1,0 +1,265 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+import json
+import os
+
+# Import the Lambda function to test
+from backend.handle_cancellation_lambda.lambda_function import lambda_handler
+
+class TestHandleCancellationLambda(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['APPOINTMENTS_TABLE_NAME'] = 'mock_appointments_table_cancel'
+        os.environ['NOTIFICATION_SQS_URL'] = 'mock_notification_sqs_url_cancel'
+        os.environ['GOOGLE_CALENDAR_SYNC_SQS_URL'] = 'mock_google_calendar_sqs_url_cancel'
+        os.environ['LOG_LEVEL'] = 'INFO'
+
+    @patch('boto3.resource')
+    @patch('boto3.client')
+    def setUp(self, mock_boto3_client, mock_boto3_resource):
+        self.mock_dynamodb_resource = MagicMock()
+        self.mock_appointments_table = MagicMock()
+        self.mock_dynamodb_resource.Table.return_value = self.mock_appointments_table
+        mock_boto3_resource.return_value = self.mock_dynamodb_resource
+
+        self.mock_sqs_client = MagicMock()
+        mock_boto3_client.return_value = self.mock_sqs_client
+        
+        self.lambda_handler = lambda_handler
+
+    def _create_api_gateway_event(self, booking_id):
+        return {
+            "pathParameters": {"id": booking_id},
+            "requestContext": {"requestId": "test-cancel-id", "http": {"method": "POST"}}
+        }
+
+    def test_successful_cancellation_with_google_calendar_event(self):
+        booking_id = "booking_with_gcal"
+        event = self._create_api_gateway_event(booking_id)
+        google_event_id = "gcal_event_123"
+
+        mock_booking_item = {
+            'bookingId': booking_id,
+            'status': 'confirmed', # Booking is confirmed
+            'googleCalendarEventId': google_event_id, # Has a Google Calendar event
+            'locationId': 'location1',
+            'clientDetails': {'name': 'Test Client', 'email': 'test@example.com'},
+            'serviceName': 'Test Service',
+            'proposedStartTime': '2024-01-01T10:00:00Z'
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'cancelled', 'updatedAt': 'some-iso-time'}
+        }
+        self.mock_sqs_client.send_message.return_value = {'MessageId': 'sqs-msg-id'}
+
+        response = self.lambda_handler(event, {})
+        
+        self.assertEqual(response['statusCode'], 200)
+        response_body = json.loads(response['body'])
+        self.assertEqual(response_body['message'], f"Booking {booking_id} cancelled successfully.")
+        self.assertEqual(response_body['booking']['status'], 'cancelled')
+
+        self.mock_appointments_table.get_item.assert_called_once_with(Key={'bookingId': booking_id})
+        self.mock_appointments_table.update_item.assert_called_once()
+        update_args = self.mock_appointments_table.update_item.call_args[1]
+        self.assertEqual(update_args['Key'], {'bookingId': booking_id})
+        self.assertEqual(update_args['ExpressionAttributeValues'][':status_val'], 'cancelled')
+
+        self.assertEqual(self.mock_sqs_client.send_message.call_count, 2)
+        
+        # Check Google Calendar SQS call (DELETE_EVENT)
+        gcal_sqs_call_args = self.mock_sqs_client.send_message.call_args_list[0][1]
+        self.assertEqual(gcal_sqs_call_args['QueueUrl'], 'mock_google_calendar_sqs_url_cancel')
+        gcal_message_body = json.loads(gcal_sqs_call_args['MessageBody'])
+        self.assertEqual(gcal_message_body['bookingId'], booking_id)
+        self.assertEqual(gcal_message_body['googleCalendarEventId'], google_event_id)
+        self.assertEqual(gcal_message_body['action'], 'DELETE_EVENT')
+
+        # Check Notification SQS call
+        notification_sqs_call_args = self.mock_sqs_client.send_message.call_args_list[1][1]
+        self.assertEqual(notification_sqs_call_args['QueueUrl'], 'mock_notification_sqs_url_cancel')
+        notification_message_body = json.loads(notification_sqs_call_args['MessageBody'])
+        self.assertEqual(notification_message_body['bookingId'], booking_id)
+        self.assertEqual(notification_message_body['notificationType'], 'BOOKING_CANCELLED')
+
+    def test_successful_cancellation_pending_booking_no_gcal_event(self):
+        booking_id = "booking_pending_no_gcal"
+        event = self._create_api_gateway_event(booking_id)
+
+        mock_booking_item = {
+            'bookingId': booking_id,
+            'status': 'pending_confirmation', # Booking is pending
+            # No googleCalendarEventId
+            'locationId': 'location2', # Still need locationId for consistency if logic were different
+            'clientDetails': {'name': 'Pending Client', 'email': 'pending@example.com'},
+            'serviceName': 'Pending Service',
+            'proposedStartTime': '2024-02-01T10:00:00Z'
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'cancelled', 'updatedAt': 'some-iso-time'}
+        }
+        self.mock_sqs_client.send_message.return_value = {'MessageId': 'sqs-msg-id-notify'}
+
+        response = self.lambda_handler(event, {})
+        
+        self.assertEqual(response['statusCode'], 200)
+        response_body = json.loads(response['body'])
+        self.assertEqual(response_body['message'], f"Booking {booking_id} cancelled successfully.")
+
+        self.mock_appointments_table.update_item.assert_called_once()
+        
+        # Only one SQS call (Notification)
+        self.mock_sqs_client.send_message.assert_called_once()
+        notification_sqs_call_args = self.mock_sqs_client.send_message.call_args_list[0][1]
+        self.assertEqual(notification_sqs_call_args['QueueUrl'], 'mock_notification_sqs_url_cancel')
+        notification_message_body = json.loads(notification_sqs_call_args['MessageBody'])
+        self.assertEqual(notification_message_body['notificationType'], 'BOOKING_CANCELLED')
+
+    def test_booking_not_found_for_cancellation(self):
+        booking_id = "booking_not_exist_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {} # No 'Item'
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 404)
+        self.assertIn(f"Booking {booking_id} not found", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+        self.mock_sqs_client.send_message.assert_not_called()
+
+    def test_booking_already_cancelled_cannot_cancel_again(self):
+        booking_id = "booking_already_cancelled"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {
+            'Item': {'bookingId': booking_id, 'status': 'cancelled'}
+        }
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 409)
+        self.assertIn(f"Booking {booking_id} cannot be cancelled. Current status: cancelled", response['body'])
+        self.mock_appointments_table.update_item.assert_not_called()
+
+    def test_booking_already_completed_cannot_cancel(self):
+        booking_id = "booking_already_completed"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.return_value = {
+            'Item': {'bookingId': booking_id, 'status': 'completed'}
+        }
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 409)
+        self.assertIn(f"Booking {booking_id} cannot be cancelled. Current status: completed", response['body'])
+
+    def test_dynamodb_get_item_error_on_cancellation(self):
+        booking_id = "booking_ddb_get_error_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        self.mock_appointments_table.get_item.side_effect = Exception("DynamoDB get_item failed during cancel")
+        
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Failed to fetch booking details.", response['body'])
+
+    def test_dynamodb_update_item_error_on_cancellation(self):
+        booking_id = "booking_ddb_update_error_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        mock_booking_item = {'bookingId': booking_id, 'status': 'confirmed'}
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.side_effect = Exception("DynamoDB update_item failed during cancel")
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Failed to update booking status.", response['body'])
+        self.mock_sqs_client.send_message.assert_not_called() # No SQS if DB update fails
+
+    def test_sqs_send_gcal_error_still_sends_notification(self):
+        booking_id = "booking_sqs_gcal_err_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        google_event_id = "gcal_event_456"
+        mock_booking_item = {
+            'bookingId': booking_id, 'status': 'confirmed', 
+            'googleCalendarEventId': google_event_id, 'locationId': 'locX',
+            'clientDetails': {'name': 'ClientX', 'email': 'clientx@example.com'}
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'cancelled'}
+        }
+        
+        self.mock_sqs_client.send_message.side_effect = [
+            Exception("SQS send for GCal DELETE failed"),
+            {'MessageId': 'sqs-notify-msg-id'}
+        ]
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 200) # Still 200, GCal SQS error is logged but non-fatal to cancellation itself
+        self.assertIn(f"Booking {booking_id} cancelled successfully.", response['body'])
+        
+        self.mock_appointments_table.update_item.assert_called_once()
+        self.assertEqual(self.mock_sqs_client.send_message.call_count, 2)
+        
+        # Check that the second SQS call (Notification) was made
+        notification_sqs_call_args = self.mock_sqs_client.send_message.call_args_list[1][1]
+        self.assertEqual(notification_sqs_call_args['QueueUrl'], 'mock_notification_sqs_url_cancel')
+
+    def test_sqs_send_notification_error(self):
+        booking_id = "booking_sqs_notification_err_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        mock_booking_item = {
+            'bookingId': booking_id, 'status': 'pending_confirmation', 
+            'clientDetails': {'name': 'ClientY', 'email': 'clienty@example.com'}
+        } # No GCal event ID
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'cancelled'}
+        }
+        self.mock_sqs_client.send_message.side_effect = Exception("SQS send for Notification failed")
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 200) # Still 200, Notification SQS error is logged
+        self.assertIn(f"Booking {booking_id} cancelled successfully.", response['body'])
+        self.mock_sqs_client.send_message.assert_called_once() # Attempted once
+
+    def test_missing_path_parameter_id_for_cancellation(self):
+        event = { "pathParameters": {} } 
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn("Missing booking ID in request path.", response['body'])
+
+    def test_missing_environment_variables_for_cancellation(self):
+        original_val = os.environ.pop('APPOINTMENTS_TABLE_NAME', None)
+        booking_id = "booking_env_error_cancel"
+        event = self._create_api_gateway_event(booking_id)
+        
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 500)
+        self.assertIn("Configuration error", response['body'])
+        
+        if original_val is not None:
+            os.environ['APPOINTMENTS_TABLE_NAME'] = original_val
+            
+    def test_cancellation_no_client_email(self):
+        booking_id = "booking_no_email"
+        event = self._create_api_gateway_event(booking_id)
+
+        mock_booking_item = {
+            'bookingId': booking_id,
+            'status': 'pending_confirmation',
+            'clientDetails': {'name': 'No Email Client'} # No email
+        }
+        self.mock_appointments_table.get_item.return_value = {'Item': mock_booking_item}
+        self.mock_appointments_table.update_item.return_value = {
+            'Attributes': {**mock_booking_item, 'status': 'cancelled'}
+        }
+
+        response = self.lambda_handler(event, {})
+        self.assertEqual(response['statusCode'], 200)
+        self.assertIn(f"Booking {booking_id} cancelled successfully.", response['body'])
+        self.mock_sqs_client.send_message.assert_not_called() # Notification SQS not called
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+
+# To run from project root:
+# PYTHONPATH=. python -m unittest backend.handle_cancellation_lambda.test_lambda_function
+# (Assuming __init__.py is in backend/ and backend/handle_cancellation_lambda/)


### PR DESCRIPTION
This commit introduces the backend functionality for staff to manage the booking lifecycle after a provisional booking is created by the AI agent.

Key changes:

-   **confirm_appointment_lambda**: Implemented logic to:
    -   Fetch a booking from DynamoDB.
    -   Validate its status is 'pending_confirmation'.
    -   Update status to 'confirmed'.
    -   Send SQS messages to trigger Google Calendar sync and client notification.
-   **handle_cancellation_lambda**: Implemented logic to:
    -   Fetch a booking from DynamoDB.
    -   Update status to 'cancelled'.
    -   Send SQS message to trigger Google Calendar event deletion if applicable.
    -   Send SQS message for client notification.
-   **google_calendar_sync_lambda**: Updated to:
    -   Process SQS messages for 'CREATE_EVENT' and 'DELETE_EVENT' actions.
    -   Interact with DynamoDB to fetch service/location details or update bookings with Google Calendar event IDs.
    -   Google Calendar API calls are currently stubbed.
-   **notification_lambda**: Updated to:
    -   Process SQS messages for various notification types (BOOKING_CONFIRMED, BOOKING_CANCELLED, PROVISIONAL_BOOKING_CREATED).
    -   Format notification content based on type.
    -   Actual notification dispatch (email/SMS) is stubbed.
-   **API Gateway**: Described necessary Terraform changes for `POST /bookings/{bookingId}/confirm` and `POST /bookings/{bookingId}/cancel` endpoints to invoke the new lambdas. These routes were previously commented out.
-   **Unit Tests**: Added comprehensive unit tests for `confirm_appointment_lambda` and `handle_cancellation_lambda`, mocking AWS services and covering success/error cases.

These changes lay the groundwork for staff to effectively manage appointments through dedicated API endpoints, integrating with the existing notification and calendar systems.